### PR TITLE
manifest was copied to ip rather than sv_ip, which is where the command to apply it is run

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ echo "injecting environment vars into manifest file"
 envsubst < manifest.yml > newman.yml
 
 echo "copying manifest file to supervisor node ${sv_ip}"
-sshpass -p "${sv_pass}" scp -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ./newman.yml root@"${ip}":./manifest.yml >> /dev/null
+sshpass -p "${sv_pass}" scp -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ./newman.yml root@"${sv_ip}":./manifest.yml >> /dev/null
 if [ $? -eq 0 ] ;
 then      
       echo "manifest copied sucessfully"


### PR DESCRIPTION
This script was very helpful for us, the guest cluster proxy issue makes it hard to show TMC on vSphere 7 with Kubernetes - thanks. I had to make one minor modification - on the line I changed, it copies to $ip rather than $sv_ip. This portion of the script is outside the for loop, and $ip is set to the last IP in the list of SV_IPS from your env.sh. The script would work as-is if the last IP in SV_IPS == sv_ip, which in my case it didn't. 